### PR TITLE
Initial implementation of request.post + tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+REPORTER = spec
+
+test:
+	@NODE_ENV=test ./node_modules/.bin/mocha \
+		--reporter $(REPORTER)
+
+.PHONY: test

--- a/index.js
+++ b/index.js
@@ -1,0 +1,125 @@
+var request = require('request')
+  ;
+
+// Number of retries to attempt before giving up
+var MAX_RETRIES = 3;
+
+// Time delay between retry attempts
+var RETRY_DELAY = 10000;
+
+var RequestRetry = function() {
+  // Function to execute the request
+  this.exec = undefined;
+
+  // Number request retries attempted
+  this.numRetries = 0;
+
+  // Array of response codes to attempt a retry with
+  this.retryCodes = [];
+}
+
+/**
+ * Request callback.
+ */
+function _callback(err, response, body) {
+  // Call the client-provided callback
+  if (typeof this.callback === 'function') {
+    this.callback(err, response, body);
+  }
+
+  // If error is encountered or response is received with a code we can retry with,
+  // and there are retries remaining, schedule a retry.
+  if ((err || (response && isRetryCode(this, response.statusCode))) &&
+      this.numRetries < MAX_RETRIES) {
+    this.numRetries++;
+    setTimeout(this.exec, RETRY_DELAY);
+  }
+  else {
+    this.exec = null;
+  }
+}
+
+/**
+ * Check if the response code is one that warrants a retry.
+ */
+function isRetryCode(obj, code) {
+  if (obj.retryCodes && obj.retryCodes.indexOf(code) >= 0) {
+    return true;
+  }
+  else {
+    return false;
+  }
+}
+
+/**
+ * Set request defaults.
+ */
+RequestRetry.setDefaults = function(obj) {
+  request.defaults(obj);
+}
+
+/**
+ * Set the maximum number of retries.
+ */
+RequestRetry.setMaxRetries = function(num) {
+  MAX_RETRIES = num;
+}
+
+/**
+ * Set the time delay in milliseconds before each retry.
+ */
+RequestRetry.setRetryDelay = function(delay) {
+  RETRY_DELAY = delay;
+}
+
+/**
+ * Set the array of response codes that warrant a retry.
+ */
+RequestRetry.prototype.setRetryCodes = function(codes) {
+  if (typeof codes !== 'object' || !codes || codes.length == 0) {
+    return;
+  }
+
+  this.retryCodes = codes;
+}
+
+/**
+ * Wrapper for request.post. Sets the this.exec closure with reference to url,
+ * data, and callback variables to be used in case the request needs to be retried.
+ */
+RequestRetry.prototype.post = function(url, data, callback) {
+  this.numRetries = 0;
+  
+  var _this = this;
+  _this.callback = callback;
+
+  this.exec = function() {
+    request.post(url, data, _callback.bind(_this));
+  };
+
+  this.exec();
+};
+
+module.exports = RequestRetry;
+
+
+/**
+ *
+ * Helper functions for running tests.
+ *
+ */
+if (process.env.NODE_ENV === 'test') {
+  RequestRetry.getMaxRetries = function() {
+    return MAX_RETRIES;
+  }
+
+  RequestRetry.getRetryDelay = function() {
+    return RETRY_DELAY;
+  }
+
+  RequestRetry.isRetryCode = isRetryCode;
+
+  RequestRetry.prototype.getRetryCodes = function() {
+    return this.retryCodes;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "node-request-retry",
+  "description": "A simple Node.js request wrapper for retrying http requests.",
+  "version": "0.0.1",
+  "author": {
+    "name": "DoSomething.org",
+    "email": "developers@dosomething.org",
+    "url": "http://www.dosomething.org"
+  },
+  "repository": {
+    "url": "https://github.com/DoSomething/node-request-retry"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "make test"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "request": "^2.48.0"
+  },
+  "devDependencies": {
+    "mocha": "^2.0.0"
+  }
+}

--- a/test/retryrequest.test.js
+++ b/test/retryrequest.test.js
@@ -1,0 +1,76 @@
+var assert = require('assert')
+  , RequestRetry = require('../')
+  ;
+
+describe('RequestRetry.setMaxRetries(5)', function() {
+  var original;
+  before(function() {
+    original = RequestRetry.getMaxRetries();
+  });
+
+  it('should set MAX_RETRIES to 5', function() {
+    RequestRetry.setMaxRetries(5);
+    assert(RequestRetry.getMaxRetries() === 5);
+  });
+
+  after(function() {
+    RequestRetry.setMaxRetries(original);
+  });
+});
+
+describe('RequestRetry.setRetryDelay(1000)', function() {
+  var original;
+  before(function() {
+    original = RequestRetry.getRetryDelay();
+  });
+
+  it('should set RETRY_DELAY to 1000', function() {
+    RequestRetry.setRetryDelay(1000);
+    assert(RequestRetry.getRetryDelay() === 1000);
+  })
+
+  after(function() {
+    RequestRetry.setRetryDelay(original);
+  });
+});
+
+describe('RequestRetry.prototype.setRetryCodes()', function() {
+  var request = new RequestRetry();
+
+  it('should set an empty array if passed `undefined`', function() {
+    request.setRetryCodes(undefined);
+    var test = request.getRetryCodes();
+    assert(typeof test === 'object' && test.length === 0);
+  });
+
+  it('should set an array if passed `[400,408,500]`', function() {
+    request.setRetryCodes([400, 408, 500]);
+    var test = request.getRetryCodes();
+    assert(typeof test === 'object' && test.length === 3);
+    assert(test[0] === 400 && test[1] === 408 && test[2] === 500);
+  });
+
+  after(function() {
+    request = null;
+  });
+});
+
+describe('RequestRetry.isRetryCode() when retryCodes = [408]', function() {
+  var request = new RequestRetry();
+
+  before(function() {
+    request.setRetryCodes([408]);
+  });
+
+  it('should return false if code is 200', function() {
+    assert(RequestRetry.isRetryCode(request, 200) === false);
+  });
+
+  it('should return false if code is 408', function() {
+    assert(RequestRetry.isRetryCode(request, 408) === true);
+  });
+
+  after(function() {
+    request = null;
+  });
+});


### PR DESCRIPTION
#### What's this PR do?

This provides an initial implementation of retrying POST requests. It's a wrapper around the Node.js request module, so usage should look pretty similar.

```
var RequestRetry = require('node-request-retry');
var requestRetry = new RequestRetry();
requestRetry.post(url, data, function(err, response, body) {
  ...
});
```
#### Where should the reviewer start?
###### index.js

The `.post` method here sets `this.exec` as a closure with reference to `url` and `data`. We provide our own internal `_callback` and bind the passed in `callback` to it. The request is then executed with `this.exec()`.

When the request returns, our internal `_callback` is called which then passes on the info to the original caller's `callback`. If an error is returned of some sort, we attempt to retry up to `MAX_RETRIES` using `setTimeout`. We're able to use `this.exec` in `setTimeout` because it's got references to `url` and `data`.
#### How should this be manually tested?

For now you can just run `npm test`. We'll see it in practice once we roll it into https://github.com/DoSomething/ds-mdata-responder.
#### Any background context?

This is the result of trying to solve for https://github.com/DoSomething/ds-mdata-responder/issues/291

cc: @tongxiang 
