### PR TITLE
Retry condition with function callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,20 @@ var RequestRetry = require('node-request-retry');
 
 var requestRetry = new RequestRetry();
 
-// Retry if the response received is one of the following codes
-requestRetry.setRetryCodes([400, 404, 408, 500]);
+var retryConditions = [];
+// Retries can be triggered by either receiving a certain status code
+Array.prototype.push.apply(retryConditions, [400, 404, 408, 500]);
+
+// ... or by evaluating a function. Returning true means the request should be retried.
+var fnShouldRetry = function(response, body) {
+  if (body == false)
+    return true;
+  else
+    return false;
+};
+retryConditions[retryConditions.length] = fnShouldRetry;
+
+requestRetry.setRetryCodes(retryConditions);
 
 // POST
 requestRetry.post(url, postData, function(err, response, body) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-request-retry",
   "description": "A simple Node.js request wrapper for retrying http requests.",
-  "version": "0.0.2",
+  "version": "1.0.0",
   "author": {
     "name": "DoSomething.org",
     "email": "developers@dosomething.org",


### PR DESCRIPTION
#### What's this PR do?

In addition to defining status codes that should trigger a retry, you can also set functions that'll evaluate whether or not a request should be retried.
#### Where should the reviewer start?

`RequestRetry.retryCodes` has been replaced by `RequestRetry.retryCondition`. It's still an array. It just might also have functions in there as opposed to only numbers.

The meat of the work is in `RequestRetry.isRetryCondition()`. If the element being evaluated is a number, we'll check it against the `response.statusCode` like we did before. But if it's a function, we pass the response and body data on to be evaluated. A return of `true` means we should retry.
#### How should this be manually tested?

`npm test`
#### Any background context?

I'm looking to use this to add some retry logic to the report back code in DoSomething/ds-mdata-responder.

@tongxiang 
